### PR TITLE
Implemented ListableResource trait so metrics responses can be easily parsed by k8s-openapi

### DIFF
--- a/src/metrics/v1beta1/node.rs
+++ b/src/metrics/v1beta1/node.rs
@@ -18,6 +18,10 @@ impl k8s::Resource for NodeMetrics {
     type Scope = k8s::ClusterResourceScope;
 }
 
+impl k8s::ListableResource for NodeMetrics {
+    const LIST_KIND: &'static str = "NodeMetricsList";
+}
+
 impl k8s::Metadata for NodeMetrics {
     type Ty = metav1::ObjectMeta;
 

--- a/src/metrics/v1beta1/pod.rs
+++ b/src/metrics/v1beta1/pod.rs
@@ -18,6 +18,10 @@ impl k8s::Resource for PodMetrics {
     type Scope = k8s::NamespaceResourceScope;
 }
 
+impl k8s::ListableResource for PodMetrics {
+    const LIST_KIND: &'static str = "PodMetricsList";
+}
+
 impl k8s::Metadata for PodMetrics {
     type Ty = metav1::ObjectMeta;
 


### PR DESCRIPTION
This allows patterns like 

```rust
    let response = match reqwest::blocking::get(metrics_url).unwrap();

    let parsed_response: ListResponse<NodeMetrics> =
        ListResponse::<NodeMetrics>::try_from_parts(
            response.status(),
            response.bytes().unwrap().as_ref()
        ).unwrap();
```

instead of having to manually parse using serde and then unwrapping the list