### PR TITLE
bump `k8s-openapi` dependency to 0.19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k8s-metrics"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 rust-version = "1.61"
 description = "K8s Metrics API Resource definitions"
@@ -10,12 +10,12 @@ license = "Apache-2.0"
 
 [dependencies]
 go-parse-duration = "0.1"
-k8s-openapi = { version = "0.18", features = [] }
+k8s-openapi = { version = "0.19", features = [] }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 
 [dev-dependencies]
-k8s-openapi = { version = "0.18", features = ["v1_26"] }
+k8s-openapi = { version = "0.19", features = ["v1_27"] }
 
 [package.metadata.docs.rs]
-features = ["k8s-openapi/v1_26"]
+features = ["k8s-openapi/v1_27"]

--- a/release.toml
+++ b/release.toml
@@ -6,4 +6,4 @@ verify = true
 pre-release-commit-message = "Bump version to {{version}}"
 tag-message = "{{version}}"
 tag-name = "{{version}}"
-enable-features = ["k8s-openapi/v1_26"]
+enable-features = ["k8s-openapi/v1_27"]


### PR DESCRIPTION
This PR just bumps the k8s-openapi version to 0.19 so it becomes compatible with latest `kube` release.

I also changed the dev feature to v1_27 but I wasn't sure if that is needed at all.