### PR TITLE
update crate k8s-openapi to version: 0.22.0 && kube to version: 0.91.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,14 @@ license = "Apache-2.0"
 
 [dependencies]
 go-parse-duration = "0.1"
-k8s-openapi = { version = "0.21", features = [] }
+k8s-openapi = { version = "0.22.0", features = [] }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 
 
 [dev-dependencies]
-k8s-openapi = { version = "0.21", features = ["latest"] }
-kube = { version = "0.88" }
+k8s-openapi = { version = "0.22.0", features = ["latest"] }
+kube = { version = "0.91.0" }
 tokio = { version = "1.35", features = ["full"] }
 
 


### PR DESCRIPTION
update crate k8s-openapi to version: 0.22.0
update crate kube to version: 0.91.0