### PR TITLE
added partial eq derive

### DIFF
--- a/src/metrics/v1beta1.rs
+++ b/src/metrics/v1beta1.rs
@@ -7,13 +7,13 @@ mod duration;
 mod node;
 mod pod;
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
 pub struct Usage {
     pub cpu: resource::Quantity,
     pub memory: resource::Quantity,
 }
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
 pub struct Container {
     pub name: String,
     pub usage: Usage,

--- a/src/metrics/v1beta1/node.rs
+++ b/src/metrics/v1beta1/node.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct NodeMetrics {
     pub metadata: metav1::ObjectMeta,
     pub timestamp: metav1::Time,

--- a/src/metrics/v1beta1/pod.rs
+++ b/src/metrics/v1beta1/pod.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct PodMetrics {
     pub metadata: metav1::ObjectMeta,
     pub containers: Vec<Container>,


### PR DESCRIPTION
standard structures has `PartialEq`

Node for example
```rust
#[derive(Clone, Debug, Default, PartialEq)]
pub struct Node {
    /// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
    pub metadata: crate::apimachinery::pkg::apis::meta::v1::ObjectMeta,

    /// Spec defines the behavior of a node. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
    pub spec: Option<crate::api::core::v1::NodeSpec>,

    /// Most recently observed status of the node. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
    pub status: Option<crate::api::core::v1::NodeStatus>,
}
```