### PR TITLE
Metrics server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,6 +436,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -396,6 +454,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -520,6 +579,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "k8s-metrics-server"
+version = "0.28.0"
+dependencies = [
+ "axum",
+ "k8s-metrics",
+ "k8s-openapi",
+ "kube",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower",
+]
+
+[[package]]
 name = "k8s-openapi"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -614,6 +687,12 @@ name = "log"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
@@ -916,6 +995,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,6 +1123,29 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "annotate-snippets"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,6 +170,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
+
+[[package]]
 name = "constcat"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,6 +220,12 @@ dependencies = [
  "generic-array",
  "typenum",
 ]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "derive_more"
@@ -513,6 +539,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -549,6 +608,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -579,17 +639,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "k8s-metrics-collector"
+version = "0.28.0"
+dependencies = [
+ "k8s-metrics",
+ "k8s-metrics-ext",
+ "k8s-metrics-kubeapi",
+ "k8s-openapi",
+ "kube",
+ "prometheus-parse",
+ "time",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "k8s-metrics-ext"
+version = "0.28.0"
+dependencies = [
+ "k8s-metrics",
+ "k8s-openapi",
+]
+
+[[package]]
+name = "k8s-metrics-kubeapi"
+version = "0.28.0"
+dependencies = [
+ "k8s-metrics-ext",
+ "k8s-openapi",
+ "kube",
+ "prometheus-parse",
+ "tracing",
+]
+
+[[package]]
 name = "k8s-metrics-server"
 version = "0.28.0"
 dependencies = [
  "axum",
+ "constcat",
  "k8s-metrics",
+ "k8s-metrics-collector",
+ "k8s-metrics-ext",
+ "k8s-metrics-kubeapi",
  "k8s-openapi",
  "kube",
- "serde",
- "serde_json",
+ "time",
  "tokio",
  "tower",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -668,6 +767,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -687,6 +792,15 @@ name = "log"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "matchit"
@@ -722,6 +836,21 @@ name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -857,12 +986,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prometheus-parse"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "811031bea65e5a401fb2e1f37d802cca6601e204ac463809a3189352d13b78a5"
+dependencies = [
+ "chrono",
+ "itertools",
+ "once_cell",
+ "regex",
 ]
 
 [[package]]
@@ -1160,6 +1307,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1239,6 +1395,34 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "tokio"
@@ -1369,6 +1553,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1406,6 +1620,12 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"
@@ -1483,10 +1703,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = ["k8s-metrics"]
+members = ["k8s-metrics", "k8s-metrics-server"]
 
 
 [workspace.package]
@@ -20,6 +20,9 @@ serde = { version = "1.0", features = ["derive"] }
 thiserror = "2.0"
 tokio = { version = "1.52.3", features = ["full"] }
 
+# Local dependencies
+k8s-metrics = { path = "./k8s-metrics" }
+ 
 
 [workspace.lints.clippy]
 explicit_iter_loop = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,12 @@
 [workspace]
 resolver = "3"
-members = ["k8s-metrics", "k8s-metrics-server"]
+members = [
+    "k8s-metrics",
+    "k8s-metrics-collector",
+    "k8s-metrics-ext",
+    "k8s-metrics-kubeapi",
+    "k8s-metrics-server",
+]
 
 
 [workspace.package]
@@ -12,17 +18,26 @@ license = "Apache-2.0"
 
 
 [workspace.dependencies]
+axum = "0.8"
 constcat = "0.6"
 go-parse-duration = "0.1"
 k8s-openapi = { version = "0.28", features = [] }
 kube = { version = "4.0" }
+prometheus-parse = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "2.0"
-tokio = { version = "1.52.3", features = ["full"] }
+time = "0.3"
+tokio = { version = "1.52", features = ["full"] }
+tower = "0.5"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 
 # Local dependencies
 k8s-metrics = { path = "./k8s-metrics" }
- 
+k8s-metrics-collector = { path = "./k8s-metrics-collector" }
+k8s-metrics-ext = { path = "./k8s-metrics-ext" }
+k8s-metrics-kubeapi = { path = "./k8s-metrics-kubeapi" }
+
 
 [workspace.lints.clippy]
 explicit_iter_loop = "warn"

--- a/k8s-metrics-collector/Cargo.toml
+++ b/k8s-metrics-collector/Cargo.toml
@@ -1,29 +1,22 @@
 [package]
-name = "k8s-metrics-server"
-description = "K8s metrics server"
-edition = "2024"
-
+name = "k8s-metrics-collector"
 version.workspace = true
-# edition.workspace = true
+edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true
 license.workspace = true
 
 
 [dependencies]
-axum.workspace = true
-constcat.workspace = true
 k8s-metrics.workspace = true
-k8s-metrics-collector.workspace = true
 k8s-metrics-ext.workspace = true
 k8s-metrics-kubeapi.workspace = true
 k8s-openapi = { workspace = true, features = ["latest"] }
 kube.workspace = true
-tokio.workspace = true
-tower.workspace = true
+prometheus-parse.workspace = true
 time.workspace = true
+tokio.workspace = true
 tracing.workspace = true
-tracing-subscriber.workspace = true
 
 
 [lints]

--- a/k8s-metrics-collector/src/lib.rs
+++ b/k8s-metrics-collector/src/lib.rs
@@ -1,0 +1,210 @@
+use std::io;
+
+use k8s_metrics::v1beta1 as metricsv1;
+use k8s_metrics_ext as k8s;
+use k8s_metrics_kubeapi::KubeApi;
+use kube::ResourceExt as _;
+use prometheus_parse::Scrape;
+use time::ext::NumericalStdDuration as _;
+use tokio::sync::Mutex;
+
+use k8s::metav1;
+use k8s::resource::Quantity;
+use k8s::TimeExt as _;
+
+#[derive(Debug)]
+pub struct MetricsCollector {
+    kubeapi: KubeApi,
+    scrapes: Mutex<Vec<String>>,
+}
+
+impl MetricsCollector {
+    pub async fn new() -> kube::Result<Self> {
+        let kubeapi = KubeApi::new().await?;
+        let scrapes = Mutex::new(Vec::new());
+        Ok(Self { kubeapi, scrapes })
+    }
+
+    pub async fn scrape_metrics(&self) {
+        let nodes = self.kubeapi.list_nodes().await.unwrap_or_default();
+        let mut metrics = String::new();
+        for node in nodes {
+            let name = node.name_any();
+            if let Ok((cadvisor, resource)) = self
+                .kubeapi
+                .scrape_node_metrics(&name)
+                .await
+                .inspect_err(|err| tracing::error!(name, ?err, "Failed to scrape metrics for node"))
+            {
+                metrics.push_str(&cadvisor);
+                metrics.push_str(&resource);
+            }
+        }
+        self.scrapes.lock().await.push(metrics);
+    }
+
+    pub fn metrics_api_resource_list(&self) -> metav1::APIResourceList {
+        self.kubeapi.metrics_api_resource_list()
+    }
+
+    #[expect(clippy::unused_async)]
+    pub async fn nodes(&self) -> Vec<metricsv1::NodeMetrics> {
+        // In a real implementation, you would collect actual metrics from the node
+        // For now, we'll return mock data
+        mock::nodes()
+    }
+
+    #[expect(clippy::unused_async)]
+    pub async fn node(&self, node: &str) -> Option<metricsv1::NodeMetrics> {
+        // In a real implementation, you would collect actual metrics from the node
+        // For now, we'll return mock data
+        (node != "node-5").then(|| mock::node(node.to_string()))
+    }
+
+    #[expect(clippy::unused_async)]
+    pub async fn pods(&self, namespace: Option<String>) -> Vec<metricsv1::PodMetrics> {
+        mock::pods(namespace)
+    }
+
+    #[expect(clippy::unused_async)]
+    pub async fn pod(&self, name: &str, namespace: &str) -> Option<metricsv1::PodMetrics> {
+        (name != "xyz").then(|| mock::pod(name.to_string(), namespace.to_string()))
+    }
+
+    pub async fn scrapes(&self) -> Option<String> {
+        self.scrapes.lock().await.last().cloned()
+    }
+
+    pub async fn parse_scrape(&self) -> io::Result<Scrape> {
+        let locked = self.scrapes.lock().await;
+        let lines = locked
+            .last()
+            .map(|text| text.as_str())
+            .unwrap_or_default()
+            .lines()
+            .map(|line| Ok(line.to_string()));
+        // let text = locked.last().map(|text| text.as_str()).unwrap_or_default();
+        // let lines = text.lines().map(|line| Ok(line.to_string()));
+        Scrape::parse(lines)
+    }
+}
+
+mod mock {
+    use super::*;
+
+    pub(super) fn nodes() -> Vec<metricsv1::NodeMetrics> {
+        vec![
+            metricsv1::NodeMetrics {
+                metadata: metav1::ObjectMeta {
+                    name: Some("demo-node-1".to_string()),
+                    creation_timestamp: Some(metav1::Time::now()),
+                    ..k8s::default()
+                },
+                timestamp: metav1::Time::now(),
+                window: 30.std_seconds(),
+                usage: metricsv1::Usage {
+                    cpu: Quantity("150m".to_string()),
+                    memory: Quantity("512Mi".to_string()),
+                },
+            },
+            metricsv1::NodeMetrics {
+                metadata: metav1::ObjectMeta {
+                    name: Some("demo-node-2".to_string()),
+                    creation_timestamp: Some(metav1::Time::now()),
+                    ..k8s::default()
+                },
+                timestamp: metav1::Time::now(),
+                window: 30.std_seconds(),
+                usage: metricsv1::Usage {
+                    cpu: Quantity("200m".to_string()),
+                    memory: Quantity("1Gi".to_string()),
+                },
+            },
+        ]
+    }
+
+    pub(super) fn node(name: String) -> metricsv1::NodeMetrics {
+        metricsv1::NodeMetrics {
+            metadata: metav1::ObjectMeta {
+                name: Some(name),
+                creation_timestamp: Some(metav1::Time::now()),
+                ..k8s::default()
+            },
+            timestamp: metav1::Time::now(),
+            window: 30.std_seconds(),
+            usage: metricsv1::Usage {
+                cpu: Quantity("100m".to_string()),
+                memory: Quantity("200Mi".to_string()),
+            },
+        }
+    }
+
+    pub(super) fn pods(namespace: Option<String>) -> Vec<metricsv1::PodMetrics> {
+        let namespace = namespace.unwrap_or_else(|| "default".to_string());
+        vec![
+            metricsv1::PodMetrics {
+                metadata: metav1::ObjectMeta {
+                    name: Some("demo-pod-1".to_string()),
+                    namespace: Some(namespace.clone()),
+                    creation_timestamp: Some(metav1::Time::now()),
+                    ..k8s::default()
+                },
+                timestamp: metav1::Time::now(),
+                window: 30.std_seconds(),
+                containers: vec![
+                    metricsv1::Container {
+                        name: "app-container".to_string(),
+                        usage: metricsv1::Usage {
+                            cpu: Quantity("25m".to_string()),
+                            memory: Quantity("64Mi".to_string()),
+                        },
+                    },
+                    metricsv1::Container {
+                        name: "sidecar-container".to_string(),
+                        usage: metricsv1::Usage {
+                            cpu: Quantity("10m".to_string()),
+                            memory: Quantity("32Mi".to_string()),
+                        },
+                    },
+                ],
+            },
+            metricsv1::PodMetrics {
+                metadata: metav1::ObjectMeta {
+                    name: Some("demo-pod-2".to_string()),
+                    namespace: Some(namespace.clone()),
+                    creation_timestamp: Some(metav1::Time::now()),
+                    ..k8s::default()
+                },
+                timestamp: metav1::Time::now(),
+                window: 30.std_seconds(),
+                containers: vec![metricsv1::Container {
+                    name: "web-server".to_string(),
+                    usage: metricsv1::Usage {
+                        cpu: Quantity("75m".to_string()),
+                        memory: Quantity("128Mi".to_string()),
+                    },
+                }],
+            },
+        ]
+    }
+
+    pub(super) fn pod(name: String, namespace: String) -> metricsv1::PodMetrics {
+        metricsv1::PodMetrics {
+            metadata: metav1::ObjectMeta {
+                name: Some(name),
+                namespace: Some(namespace),
+                creation_timestamp: Some(metav1::Time::now()),
+                ..k8s::default()
+            },
+            timestamp: metav1::Time::now(),
+            window: 30.std_seconds(),
+            containers: vec![metricsv1::Container {
+                name: "web-server".to_string(),
+                usage: metricsv1::Usage {
+                    cpu: Quantity("75m".to_string()),
+                    memory: Quantity("128Mi".to_string()),
+                },
+            }],
+        }
+    }
+}

--- a/k8s-metrics-ext/Cargo.toml
+++ b/k8s-metrics-ext/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "k8s-metrics-ext"
+description = "K8s metrics extension traits and utilities"
+
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+
+
+[dependencies]
+k8s-openapi.workspace = true
+k8s-metrics.workspace = true
+
+
+[lints]
+workspace = true

--- a/k8s-metrics-ext/src/lib.rs
+++ b/k8s-metrics-ext/src/lib.rs
@@ -1,0 +1,133 @@
+pub use k8s_metrics::metrics::v1beta1 as metricsv1;
+pub use k8s_openapi as openapi;
+pub use k8s_openapi::api::core::v1 as corev1;
+pub use k8s_openapi::apimachinery::pkg::api::resource;
+pub use k8s_openapi::apimachinery::pkg::apis::meta::v1 as metav1;
+
+pub use time::TimeExt;
+
+use openapi::Resource;
+
+mod time;
+
+pub trait PodMetricsExt {
+    fn new(name: impl ToString, namespace: impl ToString) -> Self;
+}
+
+impl PodMetricsExt for metricsv1::PodMetrics {
+    fn new(name: impl ToString, namespace: impl ToString) -> Self {
+        let metadata = metav1::ObjectMeta::with_namespace(name, namespace);
+        Self {
+            metadata,
+            ..default()
+        }
+    }
+}
+
+pub trait NodeMetricsExt {
+    fn new(name: impl ToString) -> Self;
+}
+
+impl NodeMetricsExt for metricsv1::NodeMetrics {
+    fn new(name: impl ToString) -> Self {
+        let metadata = metav1::ObjectMeta::new(name);
+        Self {
+            metadata,
+            ..default()
+        }
+    }
+}
+
+pub trait ObjectMetaExt {
+    fn new(name: impl ToString) -> Self;
+    fn with_namespace(name: impl ToString, namespace: impl ToString) -> Self;
+    fn created(self, ts: impl Into<Option<metav1::Time>>) -> Self;
+}
+
+impl ObjectMetaExt for metav1::ObjectMeta {
+    fn new(name: impl ToString) -> Self {
+        let name = Some(name.to_string());
+        Self { name, ..default() }
+    }
+
+    fn with_namespace(name: impl ToString, namespace: impl ToString) -> Self {
+        Self {
+            namespace: Some(namespace.to_string()),
+            ..Self::new(name)
+        }
+    }
+
+    fn created(self, ts: impl Into<Option<metav1::Time>>) -> Self {
+        Self {
+            creation_timestamp: ts.into(),
+            ..self
+        }
+    }
+}
+
+pub trait APIResourceExt {
+    fn api_resource() -> metav1::APIResource;
+}
+
+impl APIResourceExt for metricsv1::PodMetrics {
+    fn api_resource() -> metav1::APIResource {
+        metav1::APIResource {
+            name: Self::URL_PATH_SEGMENT.to_string(),
+            namespaced: true,
+            kind: Self::KIND.to_string(),
+            verbs: vec!["get".to_string(), "list".to_string()],
+            ..default()
+        }
+    }
+}
+
+impl APIResourceExt for metricsv1::NodeMetrics {
+    fn api_resource() -> metav1::APIResource {
+        metav1::APIResource {
+            name: Self::URL_PATH_SEGMENT.to_string(),
+            namespaced: false,
+            kind: Self::KIND.to_string(),
+            verbs: vec!["get".to_string(), "list".to_string()],
+            ..default()
+        }
+    }
+}
+
+pub trait StatusExt {
+    fn not_found<K>(name: impl ToString) -> Self
+    where
+        K: Resource;
+}
+
+impl StatusExt for metav1::Status {
+    fn not_found<K>(name: impl ToString) -> Self
+    where
+        K: Resource,
+    {
+        let kind = K::URL_PATH_SEGMENT.to_string();
+        let name = name.to_string();
+        let code = 404;
+        let message = if K::GROUP.is_empty() {
+            format!(r#"{kind} "{name}" not found"#)
+        } else {
+            format!(r#"{kind}.{group} "{name}" not found"#, group = K::GROUP)
+        };
+        let details = metav1::StatusDetails {
+            name: Some(name),
+            kind: Some(kind),
+            ..default()
+        };
+        Self {
+            code: Some(code),
+            details: Some(details),
+            message: Some(message),
+            reason: Some("NotFound".to_string()),
+            status: Some("Failure".to_string()),
+            ..default()
+        }
+    }
+}
+
+pub fn default<T: Default>() -> T {
+    T::default()
+}

--- a/k8s-metrics-ext/src/time.rs
+++ b/k8s-metrics-ext/src/time.rs
@@ -1,0 +1,13 @@
+use openapi::jiff;
+
+use super::*;
+
+pub trait TimeExt {
+    fn now() -> metav1::Time;
+}
+
+impl TimeExt for metav1::Time {
+    fn now() -> metav1::Time {
+        Self(jiff::Timestamp::now())
+    }
+}

--- a/k8s-metrics-kubeapi/Cargo.toml
+++ b/k8s-metrics-kubeapi/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "k8s-metrics-kubeapi"
+
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+
+
+[dependencies]
+k8s-metrics-ext.workspace = true
+k8s-openapi.workspace = true
+kube.workspace = true
+prometheus-parse.workspace = true
+tracing.workspace = true
+
+
+[lints]
+workspace = true

--- a/k8s-metrics-kubeapi/src/lib.rs
+++ b/k8s-metrics-kubeapi/src/lib.rs
@@ -1,0 +1,137 @@
+use std::fmt::Debug;
+
+use k8s_metrics_ext as k8s;
+use kube::api;
+use prometheus_parse::Scrape;
+
+use k8s::corev1;
+use k8s::metav1;
+use k8s::metricsv1;
+use k8s::APIResourceExt as _;
+
+pub struct KubeApi {
+    get_params: api::GetParams,
+    list_params: api::ListParams,
+    client: kube::Client,
+}
+
+impl KubeApi {
+    pub async fn new() -> kube::Result<Self> {
+        kube::Client::try_default().await.map(Self::with_client)
+    }
+
+    fn with_client(client: kube::Client) -> Self {
+        Self {
+            get_params: api::GetParams::default(),
+            list_params: api::ListParams::default(),
+            client,
+        }
+    }
+
+    #[tracing::instrument(skip(self), err)]
+    pub async fn get_node(&self, name: &str) -> kube::Result<corev1::Node> {
+        self.nodes().get(name).await
+    }
+
+    pub async fn get_pod(&self, name: &str, namespace: &str) -> kube::Result<corev1::Pod> {
+        self.pods(namespace).get(name).await
+    }
+
+    pub async fn list_nodes(&self) -> kube::Result<Vec<api::PartialObjectMeta<corev1::Node>>> {
+        let lp = self.list_params();
+        self.nodes().list_metadata(lp).await.map(|list| list.items)
+    }
+
+    pub async fn list_pods(
+        &self,
+        namespace: &str,
+    ) -> kube::Result<Vec<api::PartialObjectMeta<corev1::Pod>>> {
+        let lp = self.list_params();
+        self.pods(namespace)
+            .list_metadata(lp)
+            .await
+            .map(|list| list.items)
+    }
+
+    pub async fn list_all_pods(&self) -> kube::Result<Vec<api::PartialObjectMeta<corev1::Pod>>> {
+        let lp = self.list_params();
+        self.all_pods()
+            .list_metadata(lp)
+            .await
+            .map(|list| list.items)
+    }
+
+    pub async fn scrape_node_metrics(&self, node: &str) -> kube::Result<(String, String)> {
+        let cadvisor = self.get_node_cadvisor_metrics(node).await?;
+        let resource = self.get_node_resource_metrics(node).await?;
+        Ok((cadvisor, resource))
+    }
+
+    pub async fn scrape_node_metrics1(&self, node: &str) -> kube::Result<Scrape> {
+        let cadvisor = self.get_node_cadvisor_metrics(node).await?;
+        let resource = self.get_node_resource_metrics(node).await?;
+        let lines = cadvisor
+            .lines()
+            .chain(resource.lines())
+            .map(|line| Ok(line.to_string()));
+        Scrape::parse(lines).map_err(kube::Error::ReadEvents)
+    }
+
+    pub fn metrics_api_resource_list(&self) -> metav1::APIResourceList {
+        metav1::APIResourceList {
+            group_version: metricsv1::METRICS_API_GROUP_VERSION.to_string(),
+            resources: vec![
+                metricsv1::NodeMetrics::api_resource(),
+                metricsv1::PodMetrics::api_resource(),
+            ],
+        }
+    }
+
+    async fn raw_get(&self, name: impl AsRef<str>) -> kube::Result<String> {
+        let gp = self.get_params();
+        let request = api::Request::new("")
+            .get(name.as_ref(), gp)
+            .map_err(kube::Error::BuildRequest)?;
+        self.client.request_text(request).await
+    }
+
+    async fn get_node_cadvisor_metrics(&self, node: &str) -> kube::Result<String> {
+        let name = format!("api/v1/nodes/{node}/proxy/metrics/cadvisor");
+        self.raw_get(&name).await
+    }
+
+    async fn get_node_resource_metrics(&self, node: &str) -> kube::Result<String> {
+        let name = format!("api/v1/nodes/{node}/proxy/metrics/resource");
+        self.raw_get(&name).await
+    }
+
+    fn nodes(&self) -> api::Api<corev1::Node> {
+        api::Api::all(self.client.clone())
+    }
+
+    fn pods(&self, namespace: &str) -> api::Api<corev1::Pod> {
+        api::Api::namespaced(self.client.clone(), namespace)
+    }
+
+    fn all_pods(&self) -> api::Api<corev1::Pod> {
+        api::Api::all(self.client.clone())
+    }
+
+    fn get_params(&self) -> &api::GetParams {
+        &self.get_params
+    }
+
+    fn list_params(&self) -> &api::ListParams {
+        &self.list_params
+    }
+}
+
+impl Debug for KubeApi {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("KubeApi")
+            .field("get_params", &self.get_params)
+            .field("list_params", &self.list_params)
+            .field("client", &"<kube::Client>")
+            .finish()
+    }
+}

--- a/k8s-metrics-server/Cargo.toml
+++ b/k8s-metrics-server/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "k8s-metrics-server"
+description = "K8s metrics server"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+
+
+[dependencies]
+k8s-metrics.workspace = true
+k8s-openapi = { workspace = true, features = ["latest"] }
+kube.workspace = true
+tokio.workspace = true
+axum = "0.8"
+serde_json = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+tower = "0.5"
+
+
+[lints]
+workspace = true

--- a/k8s-metrics-server/src/ext.rs
+++ b/k8s-metrics-server/src/ext.rs
@@ -1,0 +1,9 @@
+use super::*;
+
+pub(crate) trait TimeExt {
+    fn now() -> metav1::Time {
+        metav1::Time(Utc::now())
+    }
+}
+
+impl TimeExt for metav1::Time {}

--- a/k8s-metrics-server/src/ext.rs
+++ b/k8s-metrics-server/src/ext.rs
@@ -1,9 +1,0 @@
-use super::*;
-
-pub(crate) trait TimeExt {
-    fn now() -> metav1::Time {
-        metav1::Time(Utc::now())
-    }
-}
-
-impl TimeExt for metav1::Time {}

--- a/k8s-metrics-server/src/main.rs
+++ b/k8s-metrics-server/src/main.rs
@@ -1,329 +1,152 @@
 use std::sync::Arc;
-use std::time::Duration;
 
-use axum::{extract::Path, http::StatusCode, response::IntoResponse, routing::get, Json, Router};
+use constcat::concat;
 use k8s_metrics::v1beta1 as metricsv1;
-// use k8s_metrics::v1beta1::{Container, NodeMetrics, PodMetrics, Usage};
-use k8s_openapi::api::core::v1 as corev1;
-use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
-use k8s_openapi::apimachinery::pkg::apis::meta::v1 as metav1;
-use k8s_openapi::{
-    chrono::{DateTime, Utc},
-    List,
-};
-use kube::api::{Api, ListParams};
-use kube::ResourceExt as _;
-use serde_json::{json, Value};
+use k8s_metrics_collector::MetricsCollector;
+use k8s_metrics_ext as k8s;
 
-use ext::TimeExt;
+use k8s::StatusExt as _;
+use k8s::metav1;
+use k8s::openapi::List;
 
-mod ext;
+use axum::extract::Path;
+use axum::extract::State;
+use axum::http;
+use axum::{Json, Router, response::IntoResponse, routing::get};
 
-struct MetricsCollector {
-    client: Option<kube::Client>,
-}
-
-impl MetricsCollector {
-    async fn new() -> Self {
-        match kube::Client::try_default().await {
-            Ok(client) => {
-                println!("✓ Connected to Kubernetes cluster");
-                Self {
-                    client: Some(client),
-                }
-            }
-            Err(e) => {
-                println!("⚠ Could not connect to Kubernetes cluster: {}", e);
-                println!("  Running in demo mode with mock data");
-                Self { client: None }
-            }
-        }
-    }
-
-    async fn get_node_metrics(
-        &self,
-    ) -> Result<List<metricsv1::NodeMetrics>, Box<dyn std::error::Error + Send + Sync>> {
-        match &self.client {
-            Some(client) => {
-                let nodes_api: Api<corev1::Node> = Api::all(client.clone());
-                let nodes = nodes_api.list(&ListParams::default()).await?;
-
-                let mut items = Vec::new();
-                for node in nodes.items {
-                    let node_name = node.name_any();
-
-                    // In a real implementation, you would collect actual metrics from the node
-                    // For now, we'll return mock data
-                    let node_metrics = metricsv1::NodeMetrics {
-                        metadata: metav1::ObjectMeta {
-                            name: Some(node_name),
-                            creation_timestamp: Some(metav1::Time::now()),
-                            ..default()
-                        },
-                        timestamp: metav1::Time::now(),
-                        window: Duration::from_secs(30),
-                        usage: metricsv1::Usage {
-                            cpu: Quantity("100m".to_string()),
-                            memory: Quantity("200Mi".to_string()),
-                        },
-                    };
-
-                    items.push(node_metrics);
-                }
-
-                Ok(List {
-                    metadata: metav1::ListMeta::default(),
-                    items,
-                })
-            }
-            None => {
-                // Demo mode - return mock data
-                let items = vec![
-                    metricsv1::NodeMetrics {
-                        metadata: metav1::ObjectMeta {
-                            name: Some("demo-node-1".to_string()),
-                            creation_timestamp: Some(metav1::Time::now()),
-                            ..default()
-                        },
-                        timestamp: metav1::Time::now(),
-                        window: Duration::from_secs(30),
-                        usage: metricsv1::Usage {
-                            cpu: Quantity("150m".to_string()),
-                            memory: Quantity("512Mi".to_string()),
-                        },
-                    },
-                    metricsv1::NodeMetrics {
-                        metadata: metav1::ObjectMeta {
-                            name: Some("demo-node-2".to_string()),
-                            creation_timestamp: Some(metav1::Time::now()),
-                            ..default()
-                        },
-                        timestamp: metav1::Time::now(),
-                        window: Duration::from_secs(30),
-                        usage: metricsv1::Usage {
-                            cpu: Quantity("200m".to_string()),
-                            memory: Quantity("1Gi".to_string()),
-                        },
-                    },
-                ];
-
-                Ok(List {
-                    metadata: metav1::ListMeta::default(),
-                    items,
-                })
-            }
-        }
-    }
-
-    async fn get_pod_metrics(
-        &self,
-        namespace: Option<String>,
-    ) -> Result<List<metricsv1::PodMetrics>, Box<dyn std::error::Error + Send + Sync>> {
-        match &self.client {
-            Some(client) => {
-                let pods_api: Api<corev1::Pod> = if let Some(ns) = namespace {
-                    Api::namespaced(client.clone(), &ns)
-                } else {
-                    Api::all(client.clone())
-                };
-
-                let pods = pods_api.list(&ListParams::default()).await?;
-
-                let mut items = Vec::new();
-                for pod in pods.items {
-                    let pod_name = pod.name_any();
-                    let pod_namespace = pod.namespace().unwrap_or_default();
-
-                    // Mock metrics for containers
-                    let mut containers = Vec::new();
-                    if let Some(spec) = pod.spec {
-                        for container in spec.containers {
-                            containers.push(metricsv1::Container {
-                                name: container.name,
-                                usage: metricsv1::Usage {
-                                    cpu: Quantity("50m".to_string()),
-                                    memory: Quantity("100Mi".to_string()),
-                                },
-                            });
-                        }
-                    }
-
-                    let pod_metrics = metricsv1::PodMetrics {
-                        metadata: metav1::ObjectMeta {
-                            name: Some(pod_name),
-                            namespace: Some(pod_namespace),
-                            creation_timestamp: Some(metav1::Time::now()),
-                            ..default()
-                        },
-                        timestamp: metav1::Time::now(),
-                        window: Duration::from_secs(30),
-                        containers,
-                    };
-
-                    items.push(pod_metrics);
-                }
-
-                Ok(List {
-                    metadata: metav1::ListMeta::default(),
-                    items,
-                })
-            }
-            None => {
-                // Demo mode - return mock data
-                let demo_namespace = namespace.unwrap_or_else(|| "default".to_string());
-                let items = vec![
-                    metricsv1::PodMetrics {
-                        metadata: metav1::ObjectMeta {
-                            name: Some("demo-pod-1".to_string()),
-                            namespace: Some(demo_namespace.clone()),
-                            creation_timestamp: Some(metav1::Time::now()),
-                            ..default()
-                        },
-                        timestamp: metav1::Time::now(),
-                        window: Duration::from_secs(30),
-                        containers: vec![
-                            metricsv1::Container {
-                                name: "app-container".to_string(),
-                                usage: metricsv1::Usage {
-                                    cpu: Quantity("25m".to_string()),
-                                    memory: Quantity("64Mi".to_string()),
-                                },
-                            },
-                            metricsv1::Container {
-                                name: "sidecar-container".to_string(),
-                                usage: metricsv1::Usage {
-                                    cpu: Quantity("10m".to_string()),
-                                    memory: Quantity("32Mi".to_string()),
-                                },
-                            },
-                        ],
-                    },
-                    metricsv1::PodMetrics {
-                        metadata: metav1::ObjectMeta {
-                            name: Some("demo-pod-2".to_string()),
-                            namespace: Some(demo_namespace),
-                            creation_timestamp: Some(metav1::Time::now()),
-                            ..default()
-                        },
-                        timestamp: metav1::Time::now(),
-                        window: Duration::from_secs(30),
-                        containers: vec![metricsv1::Container {
-                            name: "web-server".to_string(),
-                            usage: metricsv1::Usage {
-                                cpu: Quantity("75m".to_string()),
-                                memory: Quantity("128Mi".to_string()),
-                            },
-                        }],
-                    },
-                ];
-
-                Ok(List {
-                    metadata: metav1::ListMeta::default(),
-                    items,
-                })
-            }
-        }
-    }
-}
+const METRICS_API_ROOT: &str = concat!("/apis/", metricsv1::METRICS_API_GROUP_VERSION);
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    println!("Starting k8s-metrics-server...");
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+    tracing::info!("Starting k8s-metrics-server");
 
-    let collector = Arc::new(MetricsCollector::new().await);
+    let collector = MetricsCollector::new().await?;
+    let collector = Arc::new(collector);
 
     // Create axum router
+    let metrics = Router::new()
+        .route("/", get(get_api_discovery))
+        .route("/nodes", get(all_nodes))
+        .route("/nodes/{node}", get(node))
+        .route("/pods", get(all_pods))
+        .route("/namespaces/{namespace}/pods", get(all_namespaced_pods))
+        .route("/namespaces/{namespace}/pods/{pod}", get(namespaced_pod));
+
+    let debug = Router::new().route("/scrapes", get(scrapes));
+
     let app = Router::new()
-        .route(
-            "/apis/metrics.k8s.io/v1beta1/nodes",
-            get(get_node_metrics_handler),
-        )
-        .route(
-            "/apis/metrics.k8s.io/v1beta1/pods",
-            get(get_all_pod_metrics_handler),
-        )
-        .route(
-            "/apis/metrics.k8s.io/v1beta1/namespaces/:namespace/pods",
-            get(get_namespaced_pod_metrics_handler),
-        )
-        .route("/apis/metrics.k8s.io/v1beta1", get(get_api_discovery))
-        .route("/healthz", get(health_check))
+        .route("/healthz", get(healthz))
+        .nest("/debug", debug)
+        .nest(METRICS_API_ROOT, metrics)
         .with_state(collector);
 
-    println!("Server running on http://0.0.0.0:8080");
-
     let listener = tokio::net::TcpListener::bind("0.0.0.0:8080").await?;
+    if let Ok(addr) = listener.local_addr() {
+        tracing::info!("Listening on http://{addr}");
+    }
     axum::serve(listener, app).await?;
 
     Ok(())
 }
 
-// Handler functions
-async fn get_node_metrics_handler(
-    axum::extract::State(collector): axum::extract::State<Arc<MetricsCollector>>,
-) -> impl IntoResponse {
-    match collector.get_node_metrics().await {
-        Ok(metrics) => Json(metrics).into_response(),
-        Err(e) => {
-            eprintln!("Error getting node metrics: {}", e);
-            (StatusCode::INTERNAL_SERVER_ERROR, "Internal Server Error").into_response()
-        }
-    }
+async fn all_nodes(
+    State(collector): State<Arc<MetricsCollector>>,
+) -> Json<List<metricsv1::NodeMetrics>> {
+    let items = collector.nodes().await;
+    let list = List {
+        metadata: metav1::ListMeta::default(),
+        items,
+    };
+    Json(list)
 }
 
-async fn get_all_pod_metrics_handler(
-    axum::extract::State(collector): axum::extract::State<Arc<MetricsCollector>>,
-) -> impl IntoResponse {
-    match collector.get_pod_metrics(None).await {
-        Ok(metrics) => Json(metrics).into_response(),
-        Err(e) => {
-            eprintln!("Error getting pod metrics: {}", e);
-            (StatusCode::INTERNAL_SERVER_ERROR, "Internal Server Error").into_response()
-        }
-    }
+async fn node(
+    Path(node): Path<String>,
+    State(collector): State<Arc<MetricsCollector>>,
+) -> Result<Json<metricsv1::NodeMetrics>, NotFound<metricsv1::NodeMetrics>> {
+    collector
+        .node(&node)
+        .await
+        .map(Json)
+        .ok_or(NotFound::<metricsv1::NodeMetrics>::new(node))
 }
 
-async fn get_namespaced_pod_metrics_handler(
+async fn all_pods(
+    State(collector): State<Arc<MetricsCollector>>,
+) -> Json<List<metricsv1::PodMetrics>> {
+    let items = collector.pods(None).await;
+    let list = List {
+        metadata: metav1::ListMeta::default(),
+        items,
+    };
+    Json(list)
+}
+
+async fn all_namespaced_pods(
     Path(namespace): Path<String>,
-    axum::extract::State(collector): axum::extract::State<Arc<MetricsCollector>>,
-) -> impl IntoResponse {
-    match collector.get_pod_metrics(Some(namespace)).await {
-        Ok(metrics) => Json(metrics).into_response(),
-        Err(e) => {
-            eprintln!("Error getting namespaced pod metrics: {}", e);
-            (StatusCode::INTERNAL_SERVER_ERROR, "Internal Server Error").into_response()
-        }
-    }
+    State(collector): State<Arc<MetricsCollector>>,
+) -> Json<List<metricsv1::PodMetrics>> {
+    let items = collector.pods(Some(namespace)).await;
+    let list = List {
+        metadata: metav1::ListMeta::default(),
+        items,
+    };
+    Json(list)
 }
 
-async fn get_api_discovery() -> Json<Value> {
-    Json(json!({
-        "kind": "APIResourceList",
-        "apiVersion": "v1",
-        "groupVersion": "metrics.k8s.io/v1beta1",
-        "resources": [
-            {
-                "name": "nodes",
-                "singularName": "",
-                "namespaced": false,
-                "kind": "NodeMetrics",
-                "verbs": ["get", "list"]
-            },
-            {
-                "name": "pods",
-                "singularName": "",
-                "namespaced": true,
-                "kind": "PodMetrics",
-                "verbs": ["get", "list"]
-            }
-        ]
-    }))
+async fn namespaced_pod(
+    Path((namespace, pod)): Path<(String, String)>,
+    State(collector): State<Arc<MetricsCollector>>,
+) -> Result<Json<metricsv1::PodMetrics>, NotFound<metricsv1::PodMetrics>> {
+    collector
+        .pod(&pod, &namespace)
+        .await
+        .map(Json)
+        .ok_or(NotFound::<metricsv1::PodMetrics>::new(pod))
 }
 
-async fn health_check() -> &'static str {
+async fn get_api_discovery(
+    State(collector): State<Arc<MetricsCollector>>,
+) -> Json<metav1::APIResourceList> {
+    Json(collector.metrics_api_resource_list())
+}
+
+async fn scrapes(State(collector): State<Arc<MetricsCollector>>) -> String {
+    collector.scrape_metrics().await;
+    collector.scrapes().await.unwrap_or_default()
+}
+
+async fn healthz() -> &'static str {
     "ok"
 }
 
-fn default<T: Default>() -> T {
-    T::default()
+struct NotFound<K> {
+    name: String,
+    resource: std::marker::PhantomData<K>,
+}
+
+impl<K> NotFound<K> {
+    fn new(name: String) -> Self {
+        Self {
+            name,
+            resource: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<K> IntoResponse for NotFound<K>
+where
+    K: k8s::openapi::Resource,
+{
+    fn into_response(self) -> axum::response::Response {
+        let code = http::StatusCode::NOT_FOUND;
+        let status = metav1::Status {
+            code: Some(code.as_u16() as i32),
+            ..metav1::Status::not_found::<K>(self.name)
+        };
+        (code, Json(status)).into_response()
+    }
 }

--- a/k8s-metrics-server/src/main.rs
+++ b/k8s-metrics-server/src/main.rs
@@ -1,0 +1,329 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::{extract::Path, http::StatusCode, response::IntoResponse, routing::get, Json, Router};
+use k8s_metrics::v1beta1 as metricsv1;
+// use k8s_metrics::v1beta1::{Container, NodeMetrics, PodMetrics, Usage};
+use k8s_openapi::api::core::v1 as corev1;
+use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1 as metav1;
+use k8s_openapi::{
+    chrono::{DateTime, Utc},
+    List,
+};
+use kube::api::{Api, ListParams};
+use kube::ResourceExt as _;
+use serde_json::{json, Value};
+
+use ext::TimeExt;
+
+mod ext;
+
+struct MetricsCollector {
+    client: Option<kube::Client>,
+}
+
+impl MetricsCollector {
+    async fn new() -> Self {
+        match kube::Client::try_default().await {
+            Ok(client) => {
+                println!("✓ Connected to Kubernetes cluster");
+                Self {
+                    client: Some(client),
+                }
+            }
+            Err(e) => {
+                println!("⚠ Could not connect to Kubernetes cluster: {}", e);
+                println!("  Running in demo mode with mock data");
+                Self { client: None }
+            }
+        }
+    }
+
+    async fn get_node_metrics(
+        &self,
+    ) -> Result<List<metricsv1::NodeMetrics>, Box<dyn std::error::Error + Send + Sync>> {
+        match &self.client {
+            Some(client) => {
+                let nodes_api: Api<corev1::Node> = Api::all(client.clone());
+                let nodes = nodes_api.list(&ListParams::default()).await?;
+
+                let mut items = Vec::new();
+                for node in nodes.items {
+                    let node_name = node.name_any();
+
+                    // In a real implementation, you would collect actual metrics from the node
+                    // For now, we'll return mock data
+                    let node_metrics = metricsv1::NodeMetrics {
+                        metadata: metav1::ObjectMeta {
+                            name: Some(node_name),
+                            creation_timestamp: Some(metav1::Time::now()),
+                            ..default()
+                        },
+                        timestamp: metav1::Time::now(),
+                        window: Duration::from_secs(30),
+                        usage: metricsv1::Usage {
+                            cpu: Quantity("100m".to_string()),
+                            memory: Quantity("200Mi".to_string()),
+                        },
+                    };
+
+                    items.push(node_metrics);
+                }
+
+                Ok(List {
+                    metadata: metav1::ListMeta::default(),
+                    items,
+                })
+            }
+            None => {
+                // Demo mode - return mock data
+                let items = vec![
+                    metricsv1::NodeMetrics {
+                        metadata: metav1::ObjectMeta {
+                            name: Some("demo-node-1".to_string()),
+                            creation_timestamp: Some(metav1::Time::now()),
+                            ..default()
+                        },
+                        timestamp: metav1::Time::now(),
+                        window: Duration::from_secs(30),
+                        usage: metricsv1::Usage {
+                            cpu: Quantity("150m".to_string()),
+                            memory: Quantity("512Mi".to_string()),
+                        },
+                    },
+                    metricsv1::NodeMetrics {
+                        metadata: metav1::ObjectMeta {
+                            name: Some("demo-node-2".to_string()),
+                            creation_timestamp: Some(metav1::Time::now()),
+                            ..default()
+                        },
+                        timestamp: metav1::Time::now(),
+                        window: Duration::from_secs(30),
+                        usage: metricsv1::Usage {
+                            cpu: Quantity("200m".to_string()),
+                            memory: Quantity("1Gi".to_string()),
+                        },
+                    },
+                ];
+
+                Ok(List {
+                    metadata: metav1::ListMeta::default(),
+                    items,
+                })
+            }
+        }
+    }
+
+    async fn get_pod_metrics(
+        &self,
+        namespace: Option<String>,
+    ) -> Result<List<metricsv1::PodMetrics>, Box<dyn std::error::Error + Send + Sync>> {
+        match &self.client {
+            Some(client) => {
+                let pods_api: Api<corev1::Pod> = if let Some(ns) = namespace {
+                    Api::namespaced(client.clone(), &ns)
+                } else {
+                    Api::all(client.clone())
+                };
+
+                let pods = pods_api.list(&ListParams::default()).await?;
+
+                let mut items = Vec::new();
+                for pod in pods.items {
+                    let pod_name = pod.name_any();
+                    let pod_namespace = pod.namespace().unwrap_or_default();
+
+                    // Mock metrics for containers
+                    let mut containers = Vec::new();
+                    if let Some(spec) = pod.spec {
+                        for container in spec.containers {
+                            containers.push(metricsv1::Container {
+                                name: container.name,
+                                usage: metricsv1::Usage {
+                                    cpu: Quantity("50m".to_string()),
+                                    memory: Quantity("100Mi".to_string()),
+                                },
+                            });
+                        }
+                    }
+
+                    let pod_metrics = metricsv1::PodMetrics {
+                        metadata: metav1::ObjectMeta {
+                            name: Some(pod_name),
+                            namespace: Some(pod_namespace),
+                            creation_timestamp: Some(metav1::Time::now()),
+                            ..default()
+                        },
+                        timestamp: metav1::Time::now(),
+                        window: Duration::from_secs(30),
+                        containers,
+                    };
+
+                    items.push(pod_metrics);
+                }
+
+                Ok(List {
+                    metadata: metav1::ListMeta::default(),
+                    items,
+                })
+            }
+            None => {
+                // Demo mode - return mock data
+                let demo_namespace = namespace.unwrap_or_else(|| "default".to_string());
+                let items = vec![
+                    metricsv1::PodMetrics {
+                        metadata: metav1::ObjectMeta {
+                            name: Some("demo-pod-1".to_string()),
+                            namespace: Some(demo_namespace.clone()),
+                            creation_timestamp: Some(metav1::Time::now()),
+                            ..default()
+                        },
+                        timestamp: metav1::Time::now(),
+                        window: Duration::from_secs(30),
+                        containers: vec![
+                            metricsv1::Container {
+                                name: "app-container".to_string(),
+                                usage: metricsv1::Usage {
+                                    cpu: Quantity("25m".to_string()),
+                                    memory: Quantity("64Mi".to_string()),
+                                },
+                            },
+                            metricsv1::Container {
+                                name: "sidecar-container".to_string(),
+                                usage: metricsv1::Usage {
+                                    cpu: Quantity("10m".to_string()),
+                                    memory: Quantity("32Mi".to_string()),
+                                },
+                            },
+                        ],
+                    },
+                    metricsv1::PodMetrics {
+                        metadata: metav1::ObjectMeta {
+                            name: Some("demo-pod-2".to_string()),
+                            namespace: Some(demo_namespace),
+                            creation_timestamp: Some(metav1::Time::now()),
+                            ..default()
+                        },
+                        timestamp: metav1::Time::now(),
+                        window: Duration::from_secs(30),
+                        containers: vec![metricsv1::Container {
+                            name: "web-server".to_string(),
+                            usage: metricsv1::Usage {
+                                cpu: Quantity("75m".to_string()),
+                                memory: Quantity("128Mi".to_string()),
+                            },
+                        }],
+                    },
+                ];
+
+                Ok(List {
+                    metadata: metav1::ListMeta::default(),
+                    items,
+                })
+            }
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    println!("Starting k8s-metrics-server...");
+
+    let collector = Arc::new(MetricsCollector::new().await);
+
+    // Create axum router
+    let app = Router::new()
+        .route(
+            "/apis/metrics.k8s.io/v1beta1/nodes",
+            get(get_node_metrics_handler),
+        )
+        .route(
+            "/apis/metrics.k8s.io/v1beta1/pods",
+            get(get_all_pod_metrics_handler),
+        )
+        .route(
+            "/apis/metrics.k8s.io/v1beta1/namespaces/:namespace/pods",
+            get(get_namespaced_pod_metrics_handler),
+        )
+        .route("/apis/metrics.k8s.io/v1beta1", get(get_api_discovery))
+        .route("/healthz", get(health_check))
+        .with_state(collector);
+
+    println!("Server running on http://0.0.0.0:8080");
+
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:8080").await?;
+    axum::serve(listener, app).await?;
+
+    Ok(())
+}
+
+// Handler functions
+async fn get_node_metrics_handler(
+    axum::extract::State(collector): axum::extract::State<Arc<MetricsCollector>>,
+) -> impl IntoResponse {
+    match collector.get_node_metrics().await {
+        Ok(metrics) => Json(metrics).into_response(),
+        Err(e) => {
+            eprintln!("Error getting node metrics: {}", e);
+            (StatusCode::INTERNAL_SERVER_ERROR, "Internal Server Error").into_response()
+        }
+    }
+}
+
+async fn get_all_pod_metrics_handler(
+    axum::extract::State(collector): axum::extract::State<Arc<MetricsCollector>>,
+) -> impl IntoResponse {
+    match collector.get_pod_metrics(None).await {
+        Ok(metrics) => Json(metrics).into_response(),
+        Err(e) => {
+            eprintln!("Error getting pod metrics: {}", e);
+            (StatusCode::INTERNAL_SERVER_ERROR, "Internal Server Error").into_response()
+        }
+    }
+}
+
+async fn get_namespaced_pod_metrics_handler(
+    Path(namespace): Path<String>,
+    axum::extract::State(collector): axum::extract::State<Arc<MetricsCollector>>,
+) -> impl IntoResponse {
+    match collector.get_pod_metrics(Some(namespace)).await {
+        Ok(metrics) => Json(metrics).into_response(),
+        Err(e) => {
+            eprintln!("Error getting namespaced pod metrics: {}", e);
+            (StatusCode::INTERNAL_SERVER_ERROR, "Internal Server Error").into_response()
+        }
+    }
+}
+
+async fn get_api_discovery() -> Json<Value> {
+    Json(json!({
+        "kind": "APIResourceList",
+        "apiVersion": "v1",
+        "groupVersion": "metrics.k8s.io/v1beta1",
+        "resources": [
+            {
+                "name": "nodes",
+                "singularName": "",
+                "namespaced": false,
+                "kind": "NodeMetrics",
+                "verbs": ["get", "list"]
+            },
+            {
+                "name": "pods",
+                "singularName": "",
+                "namespaced": true,
+                "kind": "PodMetrics",
+                "verbs": ["get", "list"]
+            }
+        ]
+    }))
+}
+
+async fn health_check() -> &'static str {
+    "ok"
+}
+
+fn default<T: Default>() -> T {
+    T::default()
+}

--- a/k8s-metrics/src/lib.rs
+++ b/k8s-metrics/src/lib.rs
@@ -33,9 +33,6 @@ pub mod external_metrics;
 pub mod metrics;
 pub mod quantity;
 
-pub const METRICS_API_GROUP: &str = "metrics.k8s.io";
-pub const METRICS_API_VERSION: &str = "v1beta1";
-
 fn default<T: Default>() -> T {
     T::default()
 }

--- a/k8s-metrics/src/metrics/v1beta1.rs
+++ b/k8s-metrics/src/metrics/v1beta1.rs
@@ -1,7 +1,13 @@
+use constcat::concat;
+
 use super::*;
 
 pub use node::NodeMetrics;
 pub use pod::PodMetrics;
+
+pub const METRICS_API_GROUP: &str = "metrics.k8s.io";
+pub const METRICS_API_VERSION: &str = "v1beta1";
+pub const METRICS_API_GROUP_VERSION: &str = concat!(METRICS_API_GROUP, "/", METRICS_API_VERSION);
 
 mod duration;
 mod node;

--- a/k8s-metrics/src/metrics/v1beta1/node.rs
+++ b/k8s-metrics/src/metrics/v1beta1/node.rs
@@ -1,5 +1,3 @@
-use constcat::concat;
-
 use super::*;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -22,7 +20,7 @@ impl NodeMetrics {
 }
 
 impl k8s::Resource for NodeMetrics {
-    const API_VERSION: &'static str = concat!(METRICS_API_GROUP, "/", METRICS_API_VERSION);
+    const API_VERSION: &'static str = METRICS_API_GROUP_VERSION;
     const GROUP: &'static str = METRICS_API_GROUP;
     const KIND: &'static str = "NodeMetrics";
     const VERSION: &'static str = METRICS_API_VERSION;

--- a/k8s-metrics/src/metrics/v1beta1/pod.rs
+++ b/k8s-metrics/src/metrics/v1beta1/pod.rs
@@ -1,5 +1,3 @@
-use constcat::concat;
-
 use super::*;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -28,7 +26,7 @@ impl PodMetrics {
 }
 
 impl k8s::Resource for PodMetrics {
-    const API_VERSION: &'static str = concat!(METRICS_API_GROUP, "/", METRICS_API_VERSION);
+    const API_VERSION: &'static str = METRICS_API_GROUP_VERSION;
     const GROUP: &'static str = METRICS_API_GROUP;
     const KIND: &'static str = "PodMetrics";
     const VERSION: &'static str = METRICS_API_VERSION;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded to a modular workspace with dedicated crates for server, collector, Kubernetes metrics client, and extensions
  * Added an HTTP metrics server exposing Kubernetes-style endpoints for discovery, health, node metrics, pod metrics, and pod lookups
  * Introduced a metrics collector that scrapes, stores, and parses metric output
  * Added metrics-type and time extension utilities to simplify constructing Kubernetes-compatible objects

* **Chores**
  * Updated workspace dependencies and linting to be shared across crates

* **Breaking Changes**
  * Moved/remapped exported metrics API constants into the v1beta1 module, changing the public API surface
<!-- end of auto-generated comment: release notes by coderabbit.ai -->